### PR TITLE
Breaking: Add interpreter_address_val

### DIFF
--- a/fuguex-concrete/src/interpreter.rs
+++ b/fuguex-concrete/src/interpreter.rs
@@ -1580,4 +1580,16 @@ impl<O: Order, R: Clone + Default + 'static, const OPERAND_SIZE: usize> Interpre
     fn interpreter_space(&self) -> Arc<AddressSpace> {
         self.state.memory_space()
     }
+
+    fn interpreter_address_val(&self, address: Address) -> AddressValue {
+        // TODO: Check which one is better
+        
+        // AddressValue from translator
+        // self.translator.address(address.into())
+
+        // AddressValue from memory space
+        let space = self.state.memory_space();
+        address.into_address_value(&space)
+        // AddressValue::new(space, offset)
+    }
 }

--- a/fuguex-machine/src/traits.rs
+++ b/fuguex-machine/src/traits.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use fugue::ir::{AddressSpace, IntoAddress};
+use fugue::ir::{AddressSpace, IntoAddress, Address, AddressValue};
 use fugue::ir::il::Location;
 use fugue::ir::il::pcode::{Operand, PCodeOp};
 use fugue::ir::space::AddressSpaceId;
@@ -105,4 +105,5 @@ pub trait Interpreter {
     }
 
     fn interpreter_space(&self) -> Arc<AddressSpace>;
+    fn interpreter_address_val(&self, address: Address) -> AddressValue;
 }


### PR DESCRIPTION
Add interpreter_address_val trait for Interpreter
The concolic and other engines that uses the Interpreter
need to be updated

(cherry picked from commit b4fc027dd3f52ced5c66ead61301ac4eb4e35ddf)